### PR TITLE
Support for the New DR Spectrometer Mode and Better Time

### DIFF
--- a/DRX/HDF5/README.md
+++ b/DRX/HDF5/README.md
@@ -55,7 +55,7 @@ Given an HDF5 file containing linear polarization products, compute the related
 Stokes parameters and save the results to a new file.  The combinations supported
 are:
   * XX and YY -> I and Q
-  * XY and YX -> U and V
+  * XY_real and XY_imag -> U and V
 
 stokes2linear.py
 ----------------
@@ -63,10 +63,9 @@ Given an HDF5 file containing Stokes parameters, compute the related linear
 polarization products and save the results to a new file.  The combinations supported
 are:
   * I and Q -> XX and YY
-  * U and V -> XY and YX
+  * U and V -> XY_real and XY_imag
 
 plotHDF.py
 ----------
 Version of plotWaterfall.py for viewing HDF5 files created by hdfWaterfall.py and
 drspec2hdf.py.  This viewer supports all linear and Stokes data products.
-

--- a/DRX/HDF5/calculateSK.py
+++ b/DRX/HDF5/calculateSK.py
@@ -158,8 +158,8 @@ def main(args):
                         else:
                             maskDP[:,:] = maskBase[:,:]
                             
-                    elif dp in ('XY', 'YX') or dp in ('XY_real', 'XY_imag'):
-                        ## Case 2 - Flag XY/XY_real and YX/XY_imag off XX and YY
+                    elif dp in ('XY_real', 'XY_imag'):
+                        ## Case 2 - Flag XY_real and XY_imag off XX and YY
                         
                         ## Pull out the Mask group from the HDF5 file
                         mask = tuning.get('Mask', None)
@@ -205,7 +205,7 @@ if __name__ == "__main__":
     parser.add_argument('-t', '--threshold', type=aph.positive_float, default=4.0, 
                         help='masking threshold, in sigma, if the -g/--generate-mask flag is set')
     parser.add_argument('-f', '--fill', action='store_true', 
-                        help='fill in the secondary polarizations, i.e., XY, YX; Q, U, V; RL, LR, using the mask from the primaries: XX, YY; I; RR, LL')
+                        help='fill in the secondary polarizations, i.e., XY_real, XY_imag; Q, U, V; RL, LR, using the mask from the primaries: XX, YY; I; RR, LL')
     parser.add_argument('-m', '--merge', action='store_true', 
                         help='merge the new mask table with the existing one, if it exists')
     args = parser.parse_args()

--- a/DRX/HDF5/calculateSK.py
+++ b/DRX/HDF5/calculateSK.py
@@ -158,8 +158,8 @@ def main(args):
                         else:
                             maskDP[:,:] = maskBase[:,:]
                             
-                    elif dp in ('XY', 'YX'):
-                        ## Case 2 - Flag XY and YX off XX and YY
+                    elif dp in ('XY', 'YX') or dp in ('XY_real', 'XY_imag'):
+                        ## Case 2 - Flag XY/XY_real and YX/XY_imag off XX and YY
                         
                         ## Pull out the Mask group from the HDF5 file
                         mask = tuning.get('Mask', None)

--- a/DRX/HDF5/data.py
+++ b/DRX/HDF5/data.py
@@ -289,6 +289,9 @@ def fill_from_metabundle(f, tarball):
                 if station == 'lwasv':
                     nstand = 256
                     label_base = 'ADP'
+                elif station == 'ovrolwa':
+                    nstand = 352
+                    label_base = 'OVR'
                     
                 cbfg = grp.create_group('CustomBeamforming')
                 dlys = cbfg.create_dataset('Delays', (len(obsD['steps']), nstand*2+1), 'f4')
@@ -358,7 +361,7 @@ def fill_from_sdf(f, sdfFilename, station=None):
     
     # Station information
     if station is not None:
-        if station in ('lwa1', 'lwasv'):
+        if station in ('lwa1', 'lwasv', 'ovrolwa'):
             f.attrs['StationName'] = station
         else:
             raise ValueError("Unknown station name: %s" % station)
@@ -437,6 +440,9 @@ def fill_from_sdf(f, sdfFilename, station=None):
                 if station == 'lwasv':
                     nstand = 256
                     label_base = 'ADP'
+                elif station == 'ovrolwa':
+                    nstand = 352
+                    label_base = 'OVR'
                     
                 cbfg = grp.create_group('CustomBeamforming')
                 dlys = cbfg.create_dataset('Delays', (len(obsS.steps), nstand*2+1), 'f4')

--- a/DRX/HDF5/data.py
+++ b/DRX/HDF5/data.py
@@ -146,7 +146,7 @@ def fill_minimum(f, obsID, beam, srate, srateUnits='samples/s', station=None):
     
     # Station information
     if station is not None:
-        if station in ('lwa1', 'lwasv'):
+        if station in ('lwa1', 'lwasv', 'ovrolwa'):
             f.attrs['StationName'] = station
         else:
             raise ValueError("Unknown station name: %s" % station)
@@ -497,7 +497,7 @@ def get_observation_set(f, observation):
     return obs
 
 
-def create_observation_sets(f, observation, tuning, frequency, chunks, data_products=['XX', 'YY']):
+def create_observation_set(f, observation, tuning, frequency, chunks, data_products=['XX', 'YY']):
     """
     Fill in a tuning group with the right set of dummy data sets and 
     attributes.
@@ -535,7 +535,7 @@ def create_observation_sets(f, observation, tuning, frequency, chunks, data_prod
         
     # Add the dataset that stores time as a two-element quantity
     if 'time' not in obs:
-        d = grp.create_dataset('time', (chunks,), dtype=numpy.dtype({"names:" ["int", "frac"],
+        d = obs.create_dataset('time', (chunks,), dtype=numpy.dtype({"names": ["int", "frac"],
                                                                      "formats": ["i8", "f8"]}))
         d.attrs['format'] = 'unix'
         d.attrs['scale'] = 'utc'
@@ -570,7 +570,7 @@ def get_time(f, observation):
         
     # Get the data set
     try:
-        d = grp['time'']
+        d = obs['time']
     except:
         raise RuntimeError("Unknown data set for Observation %i: %s" % (observation, 'time'))
         

--- a/DRX/HDF5/decimateHDF.py
+++ b/DRX/HDF5/decimateHDF.py
@@ -57,33 +57,33 @@ def _fillHDF(input, output, tDecimation=1, sDecimation=1, level=0):
         if type(entity).__name__ == 'Dataset':
             ### If so, add it and fill it in
             if ent in ('Steps', 'Delays', 'Gains'):
-                entity0 = output.create_dataset(ent, entity.shape, entity.dtype.descr[0][1])
+                entity0 = output.create_dataset(ent, entity.shape, entity.dtype)
                 entity0[:] = entity[:]
                 
             elif ent == 'time':
                 newShape = (entity.shape[0]//tDecimation,)
-                entityO = output.create_dataset(ent, newShape, entity.dtype.descr[0][1])
+                entityO = output.create_dataset(ent, newShape, entity.dtype)
                 for i in xrange(newShape[0]):
                     data = entity[tDecimation*i:tDecimation*(i+1)]
                     entityO[i] = data[0]
                     
             elif ent == 'Saturation':
                 newShape = (entity.shape[0]//tDecimation, entity.shape[1])
-                entityO = output.create_dataset(ent, newShape, entity.dtype.descr[0][1])
+                entityO = output.create_dataset(ent, newShape, entity.dtype)
                 for i in xrange(newShape[0]):
                     data = entity[tDecimation*i:tDecimation*(i+1),:]
                     entityO[i,:] = data.sum(axis=0)
                     
             elif ent == 'freq':
                 newShape = (entity.shape[0]//sDecimation,)
-                entityO = output.create_dataset(ent, newShape, entity.dtype.descr[0][1])
+                entityO = output.create_dataset(ent, newShape, entity.dtype)
                 for i in xrange(newShape[0]):
                     data = entity[sDecimation*i:sDecimation*(i+1)]
                     entityO[i] = data.mean()
                     
             else:
                 newShape = (entity.shape[0]//tDecimation, entity.shape[1]//sDecimation)
-                entityO = output.create_dataset(ent, newShape, entity.dtype.descr[0][1])
+                entityO = output.create_dataset(ent, newShape, entity.dtype)
                 for i in xrange(newShape[0]):
                     data = entity[tDecimation*i:tDecimation*(i+1),:newShape[1]*sDecimation]
                     data = data.mean(axis=0)

--- a/DRX/HDF5/dedisperseHDF.py
+++ b/DRX/HDF5/dedisperseHDF.py
@@ -86,7 +86,7 @@ def main(args):
             obs['time'][:] = time
             
         # Loop over data products
-        for dp in ('XX', 'YY', 'XY', 'YX', 'XY_real', 'XY_imag', 'I', 'Q', 'U', 'V'):
+        for dp in ('XX', 'YY', 'XY_real', 'XY_imag', 'I', 'Q', 'U', 'V'):
             data1 = tuning1.get(dp, None)
             data2 = tuning2.get(dp, None)
             if data1 is None:

--- a/DRX/HDF5/dedisperseHDF.py
+++ b/DRX/HDF5/dedisperseHDF.py
@@ -63,7 +63,9 @@ def main(args):
         time = obs.get('time', None)[:]
         tuning1 = obs.get('Tuning1', None)
         tuning2 = obs.get('Tuning2', None)
-        
+        if tuning2 is None:
+            tuning2 = tuning1
+            
         # Get the frequencies
         freq1 = tuning1.get('freq', None)
         freq2 = tuning2.get('freq', None)
@@ -84,7 +86,7 @@ def main(args):
             obs['time'][:] = time
             
         # Loop over data products
-        for dp in ('XX', 'YY', 'XY', 'YX', 'I', 'Q', 'U', 'V'):
+        for dp in ('XX', 'YY', 'XY', 'YX', 'XY_real', 'XY_imag', 'I', 'Q', 'U', 'V'):
             data1 = tuning1.get(dp, None)
             data2 = tuning2.get(dp, None)
             if data1 is None:

--- a/DRX/HDF5/drspec2hdf.py
+++ b/DRX/HDF5/drspec2hdf.py
@@ -140,7 +140,7 @@ def main(args):
         else:
             raise RuntimeError("Output file '%s' already exists" % outname)
             
-    f = hdfData.createNewFile(outname)
+    f = hdfData.create_new_file(outname)
     obsList = {}
     if args.metadata is not None:
         try:
@@ -163,7 +163,7 @@ def main(args):
             
             obsList[i+1] = (sdfStart, sdfStop, obsChunks)
             
-        hdfData.fillFromMetabundle(f, args.metadata)
+        hdfData.fill_from_metabundle(f, args.metadata)
         
     elif args.sdf is not None:
         try:
@@ -186,17 +186,17 @@ def main(args):
             
             obsList[i+1] = (sdfStart, sdfStop, obsChunks)
             
-        hdfData.fillFromSDF(f, args.sdf, station=site)
+        hdfData.fill_from_sdf(f, args.sdf, station=site)
         
     else:
         obsList[1] = (beginDate, datetime(2222,12,31,23,59,59), nChunks)
         
-        hdfData.fillMinimum(f, 1, beam, srate, station=site)
+        hdfData.fill_minimum(f, 1, beam, srate, station=site)
         
     data_products = junkFrame.data_products
     for o in sorted(obsList.keys()):
         for t in (1,2):
-            hdfData.createDataSets(f, o, t, numpy.arange(LFFT, dtype=numpy.float64), obsList[o][2], data_products)
+            hdfData.create_observation_set(f, o, t, numpy.arange(LFFT, dtype=numpy.float64), obsList[o][2], data_products)
             
     f.attrs['FileGenerator'] = 'drspec2hdf.py'
     f.attrs['InputData'] = os.path.basename(args.filename)
@@ -204,10 +204,10 @@ def main(args):
     # Create the various HDF group holders
     ds = {}
     for o in sorted(obsList.keys()):
-        obs = hdfData.getObservationSet(f, o)
+        obs = hdfData.get_observation_set(f, o)
         
         ds['obs%i' % o] = obs
-        ds['obs%i-time' % o] = obs.create_dataset('time', (obsList[o][2],), 'f8')
+        ds['obs%i-time' % o] = hdfData.get_time(f, o)
         
         for t in (1,2):
             ds['obs%i-freq%i' % (o, t)] = hdfData.get_data_set(f, o, t, 'freq')
@@ -284,7 +284,7 @@ def main(args):
             firstPass = False
             
         # Load the data from the spectrometer frame into the HDF5 group
-        ds['obs%i-time' % o][j] = float(frame.time)
+        ds['obs%i-time' % o][j] = (frame.time[0], frame.time[1])
         
         ds['obs%i-Saturation1' % o][j,:] = frame.payload.saturations[0:2]
         ds['obs%i-Saturation2' % o][j,:] = frame.payload.saturations[2:4]

--- a/DRX/HDF5/hdfWaterfall.py
+++ b/DRX/HDF5/hdfWaterfall.py
@@ -126,7 +126,7 @@ def processDataBatchLinear(idf, antennas, tStart, duration, sample_rate, args, d
             print("Actual integration time is %.1f ms" % (tInt*1000.0,))
             
         # Save out some easy stuff
-        dataSets['obs%i-time' % obsID][i] = float(cTime)
+        dataSets['obs%i-time' % obsID][i] = (cTime[0], cTime[1])
         
         if (not args.without_sats):
             sats = ((data.real**2 + data.imag**2) >= 49).sum(axis=1)
@@ -244,7 +244,7 @@ def processDataBatchStokes(idf, antennas, tStart, duration, sample_rate, args, d
             print("Actual integration time is %.1f ms" % (tInt*1000.0,))
             
         # Save out some easy stuff
-        dataSets['obs%i-time' % obsID][i] = float(cTime)
+        dataSets['obs%i-time' % obsID][i] = (cTime[0], cTime[1])
         
         if (not args.without_sats):
             sats = ((data.real**2 + data.imag**2) >= 49).sum(axis=1)
@@ -408,7 +408,7 @@ def main(args):
         else:
             raise RuntimeError("Output file '%s' already exists" % outname)
             
-    f = hdfData.createNewFile(outname)
+    f = hdfData.create_new_file(outname)
     
     # Look at the metadata and come up with a list of observations.  If 
     # there are no metadata, create a single "observation" that covers the
@@ -442,7 +442,7 @@ def main(args):
             print(" #%i: %s to %s (%.3f s) at %.3f MHz" % (i, obs[0], obs[1], obs[2], obs[3]/1e6))
         print(" ")
             
-        hdfData.fillFromMetabundle(f, args.metadata)
+        hdfData.fill_from_metabundle(f, args.metadata)
         
     elif args.sdf is not None:
         try:
@@ -469,7 +469,7 @@ def main(args):
         site = 'lwa1'
         if args.lwasv:
             site = 'lwasv'
-        hdfData.fillFromSDF(f, args.sdf, station=site)
+        hdfData.fill_from_sdf(f, args.sdf, station=site)
         
     else:
         obsList[1] = (datetime.utcfromtimestamp(t1), datetime(2222,12,31,23,59,59), args.duration, srate)
@@ -477,7 +477,7 @@ def main(args):
         site = 'lwa1'
         if args.lwasv:
             site = 'lwasv'
-        hdfData.fillMinimum(f, 1, beam, srate, station=site)
+        hdfData.fill_minimum(f, 1, beam, srate, station=site)
         
     if (not args.stokes):
         data_products = ['XX', 'YY']
@@ -486,7 +486,7 @@ def main(args):
         
     for o in sorted(obsList.keys()):
         for t in (1,2):
-            hdfData.createDataSets(f, o, t, numpy.arange(LFFT, dtype=numpy.float64), int(round(obsList[o][2]/args.average)), data_products)
+            hdfData.create_observation_set(f, o, t, numpy.arange(LFFT, dtype=numpy.float64), int(round(obsList[o][2]/args.average)), data_products)
             
     f.attrs['FileGenerator'] = 'hdfWaterfall.py'
     f.attrs['InputData'] = os.path.basename(args.filename)
@@ -494,10 +494,10 @@ def main(args):
     # Create the various HDF group holders
     ds = {}
     for o in sorted(obsList.keys()):
-        obs = hdfData.getObservationSet(f, o)
+        obs = hdfData.get_observation_set(f, o)
         
         ds['obs%i' % o] = obs
-        ds['obs%i-time' % o] = obs.create_dataset('time', (int(round(obsList[o][2]/args.average)),), 'f8')
+        ds['obs%i-time' % o] = hdfData.get_time(f, o)
         
         for t in (1,2):
             ds['obs%i-freq%i' % (o, t)] = hdfData.get_data_set(f, o, t, 'freq')

--- a/DRX/HDF5/linear2stokes.py
+++ b/DRX/HDF5/linear2stokes.py
@@ -89,9 +89,7 @@ def main(args):
         pairs = 0
         if 'XX' in data_products and 'YY' in data_products:
             pairs += 1
-        if 'XY' in data_products and 'YX' in data_products:
-            pairs += 1
-        elif 'XY_real' in data_products and 'XY_imag' in data_products:
+        if 'XY_real' in data_products and 'XY_imag' in data_products:
             pairs += 1
         if pairs == 0:
             raise RuntimeError("Input file '%s' contains too few data products to form Stokes parameters" % args.filename)
@@ -198,97 +196,50 @@ def main(args):
                     for key in baseSKIn['XX'].attrs:
                         baseSKOut['Q'].attrs[key] = baseSKIn['XX'].attrs[key]
                         
-            if 'XY' in data_products and 'YX' in data_products:
-                ## U
-                print("      Computing 'U'")
-                tuningOut.create_dataset('U', tuningIn['XY'].shape, dtype=tuningIn['XY'].dtype.descr[0][1])
-                tuningOut['U'][:] = tuningIn['XY'][:] + tuningIn['YX']
-                
-                for key in tuningIn['XY'].attrs:
-                    tuningOut['U'].attrs[key] = tuningIn['XY'].attrs[key]
-                    
-                if baseMaskIn is not None:
-                    baseMaskOut.create_dataset('U', baseMaskIn['XY'].shape, dtype=baseMaskIn['XY'].dtype.descr[0][1])
-                    baseMaskOut['U'][:] = baseMaskIn['XY'][:] & baseMaskIn['YX'][:]
-                    
-                    for key in baseMaskIn['XY'].attrs:
-                        baseMaskOut['U'].attrs[key] = baseMaskIn['XY'].attrs[key]
-                        
-                if baseSKIn is not None:
-                    baseSKOut.create_dataset('U', baseSKIn['XY'].shape, dtype=baseSKIn['XY'].dtype.descr[0][1])
-                    baseSKOut['U'][:] = (baseSKIn['XY'][:] + baseSKIn['YX'][:]) / 2.0
-                    
-                    for key in baseSKIn['XY'].attrs:
-                        baseSKOut['U'].attrs[key] = baseSKIn['XY'].attrs[key]
-                        
-                ## V
-                print("      Computing 'V'")
-                tuningOut.create_dataset('V', tuningIn['XY'].shape, dtype=tuningIn['XY'].dtype.descr[0][1])
-                tuningOut['V'][:] = tuningIn['XY'][:] - tuningIn['YX']
-                
-                for key in tuningIn['XY'].attrs:
-                    tuningOut['V'].attrs[key] = tuningIn['XY'].attrs[key]
-                    
-                if baseMaskIn is not None:
-                    baseMaskOut.create_dataset('V', baseMaskIn['XY'].shape, dtype=baseMaskIn['XY'].dtype.descr[0][1])
-                    baseMaskOut['V'][:] = baseMaskIn['XY'][:] & baseMaskIn['YX'][:]
-                    
-                    for key in baseMaskIn['XY'].attrs:
-                        baseMaskOut['V'].attrs[key] = baseMaskIn['XY'].attrs[key]
-                        
-                if baseSKIn is not None:
-                    baseSKOut.create_dataset('V', baseSKIn['XY'].shape, dtype=baseSKIn['XY'].dtype.descr[0][1])
-                    baseSKOut['V'][:] = (baseSKIn['XY'][:] + baseSKIn['YX'][:]) / 2.0
-                    
-                    for key in baseSKIn['XY'].attrs:
-                        baseSKOut['V'].attrs[key] = baseSKIn['XY'].attrs[key]
-                        
-            elif 'XY_real' in data_products and 'XY_imag' in data_products:
-                XY = tuningIn['XY_real'][:] + 1j*tuningIn['XY_imag'][:]
-                
+            if 'XY_real' in data_products and 'XY_imag' in data_products:
                 ## U
                 print("      Computing 'U'")
                 tuningOut.create_dataset('U', tuningIn['XY_real'].shape, dtype=tuningIn['XY_real'].dtype.descr[0][1])
-                tuningOut['U'][:] = 2*XY.real
+                tuningOut['U'][:] = 2*tuningIn['XY_real'][:]
                 
                 for key in tuningIn['XY_real'].attrs:
                     tuningOut['U'].attrs[key] = tuningIn['XY_real'].attrs[key]
                     
                 if baseMaskIn is not None:
                     baseMaskOut.create_dataset('U', baseMaskIn['XY_real'].shape, dtype=baseMaskIn['XY_real'].dtype.descr[0][1])
-                    baseMaskOut['U'][:] = baseMaskIn['XY_real'][:] & baseMaskIn['XY_imag'][:]
+                    baseMaskOut['U'][:] = baseMaskIn['XY_real'][:]
                     
                     for key in baseMaskIn['XY_real'].attrs:
                         baseMaskOut['U'].attrs[key] = baseMaskIn['XY_real'].attrs[key]
                         
                 if baseSKIn is not None:
                     baseSKOut.create_dataset('U', baseSKIn['XY_real'].shape, dtype=baseSKIn['XY_real'].dtype.descr[0][1])
-                    baseSKOut['U'][:] = (baseSKIn['XY_real'][:] + baseSKIn['XY_imag'][:]) / 2.0
+                    baseSKOut['U'][:] = baseSKIn['XY_real'][:]
                     
                     for key in baseSKIn['XY_real'].attrs:
                         baseSKOut['U'].attrs[key] = baseSKIn['XY_real'].attrs[key]
                         
                 ## V
                 print("      Computing 'V'")
-                tuningOut.create_dataset('V', tuningIn['XY_real'].shape, dtype=tuningIn['XY_real'].dtype.descr[0][1])
-                tuningOut['V'][:] = 2*XY.imag
+                tuningOut.create_dataset('V', tuningIn['XY_imag'].shape, dtype=tuningIn['XY_imag'].dtype.descr[0][1])
+                tuningOut['V'][:] = 2*tuningIn['XY_imag']
                 
-                for key in tuningIn['XY_real'].attrs:
-                    tuningOut['V'].attrs[key] = tuningIn['XY_real'].attrs[key]
+                for key in tuningIn['XY_imag'].attrs:
+                    tuningOut['V'].attrs[key] = tuningIn['XY_imag'].attrs[key]
                     
                 if baseMaskIn is not None:
-                    baseMaskOut.create_dataset('V', baseMaskIn['XY_real'].shape, dtype=baseMaskIn['XY_real'].dtype.descr[0][1])
-                    baseMaskOut['V'][:] = baseMaskIn['XY_real'][:] & baseMaskIn['XY_imag'][:]
+                    baseMaskOut.create_dataset('V', baseMaskIn['XY_imag'].shape, dtype=baseMaskIn['XY_imag'].dtype.descr[0][1])
+                    baseMaskOut['V'][:] =  baseMaskIn['XY_imag'][:]
                     
-                    for key in baseMaskIn['XY_real'].attrs:
-                        baseMaskOut['V'].attrs[key] = baseMaskIn['XY_real'].attrs[key]
+                    for key in baseMaskIn['XY_imag'].attrs:
+                        baseMaskOut['V'].attrs[key] = baseMaskIn['XY_imag'].attrs[key]
                         
                 if baseSKIn is not None:
-                    baseSKOut.create_dataset('V', baseSKIn['XY_real'].shape, dtype=baseSKIn['XY_real'].dtype.descr[0][1])
-                    baseSKOut['V'][:] = (baseSKIn['XY_real'][:] + baseSKIn['XY_imag'][:]) / 2.0
+                    baseSKOut.create_dataset('V', baseSKIn['XY_imag'].shape, dtype=baseSKIn['XY_imag'].dtype.descr[0][1])
+                    baseSKOut['V'][:] = baseSKIn['XY_imag'][:]
                     
-                    for key in baseSKIn['XY_real'].attrs:
-                        baseSKOut['V'].attrs[key] = baseSKIn['XY_real'].attrs[key]
+                    for key in baseSKIn['XY_imag'].attrs:
+                        baseSKOut['V'].attrs[key] = baseSKIn['XY_imag'].attrs[key]
                         
     # Done!
     hIn.close()

--- a/DRX/HDF5/plotHDF.py
+++ b/DRX/HDF5/plotHDF.py
@@ -405,13 +405,16 @@ class Waterfall_GUI(object):
             del part
             
         self.sats = numpy.empty((self.iDuration, 4), dtype=numpy.float32)
-        part = numpy.empty((self.iDuration, 2), dtype=tuning1['Saturation'].dtype)
-        tuning1['Saturation'].read_direct(part, selection)
-        self.sats[:,0:2] = part / (self.tInt * self.srate)
-        part = numpy.empty((self.iDuration, 2), dtype=tuning2['Saturation'].dtype)
-        tuning2['Saturation'].read_direct(part, selection)
-        self.sats[:,2:4] = part / (self.tInt * self.srate)
-        del part
+        try:
+            part = numpy.empty((self.iDuration, 2), dtype=tuning1['Saturation'].dtype)
+            tuning1['Saturation'].read_direct(part, selection)
+            self.sats[:,0:2] = part / (self.tInt * self.srate)
+            part = numpy.empty((self.iDuration, 2), dtype=tuning2['Saturation'].dtype)
+            tuning2['Saturation'].read_direct(part, selection)
+            self.sats[:,2:4] = part / (self.tInt * self.srate)
+            del part
+        except KeyError:
+            pass
         # Mask out negative saturation values since that indicates the data is
         # not available
         self.sats = numpy.ma.array(self.sats, mask=(self.sats < 0))

--- a/DRX/HDF5/stokes2linear.py
+++ b/DRX/HDF5/stokes2linear.py
@@ -81,7 +81,7 @@ def main(args):
                 pass
                 
         ## Linear
-        if 'XX' in data_products or 'YY' in data_products or 'XY' in data_products or 'YX' in data_products:
+        if 'XX' in data_products or 'YY' in data_products or 'XY_real' in data_products or 'XY_imag' in data_products:
             raise RuntimeError("Input file '%s' contains data products %s" % (args.filename, ', '.join(data_products)))
             
         ## Minimum information
@@ -194,49 +194,49 @@ def main(args):
                         baseSKOut['YY'].attrs[key] = baseSKIn['I'].attrs[key]
                         
             if 'U' in data_products and 'V' in data_products:
-                ## XY
-                print("      Computing 'XY'")
-                tuningOut.create_dataset('XY', tuningIn['U'].shape, dtype=tuningIn['U'].dtype.descr[0][1])
-                tuningOut['XY'][:] = (tuningIn['U'][:] + tuningIn['V'])/2.0
+                ## XY_real
+                print("      Computing 'XY_real'")
+                tuningOut.create_dataset('XY_real', tuningIn['U'].shape, dtype=tuningIn['U'].dtype.descr[0][1])
+                tuningOut['XY_real'][:] = tuningIn['U'][:]/2.0
                 
                 for key in tuningIn['U'].attrs:
-                    tuningOut['XY'].attrs[key] = tuningIn['U'].attrs[key]
+                    tuningOut['XY_real'].attrs[key] = tuningIn['U'].attrs[key]
                     
                 if baseMaskIn is not None:
-                    baseMaskOut.create_dataset('XY', baseMaskIn['U'].shape, dtype=baseMaskIn['U'].dtype.descr[0][1])
-                    baseMaskOut['XY'][:] = baseMaskIn['U'][:] & baseMaskIn['V'][:]
+                    baseMaskOut.create_dataset('XY_real', baseMaskIn['U'].shape, dtype=baseMaskIn['U'].dtype.descr[0][1])
+                    baseMaskOut['XY_real'][:] = baseMaskIn['U'][:]
                     
                     for key in baseMaskIn['U'].attrs:
-                        baseMaskOut['XY'].attrs[key] = baseMaskIn['U'].attrs[key]
+                        baseMaskOut['XY_real'].attrs[key] = baseMaskIn['U'].attrs[key]
                         
                 if baseSKIn is not None:
-                    baseSKOut.create_dataset('XY', baseSKIn['U'].shape, dtype=baseSKIn['U'].dtype.descr[0][1])
-                    baseSKOut['XY'][:] = (baseSKIn['U'][:] + baseSKIn['V'][:]) / 2.0
+                    baseSKOut.create_dataset('XY_real', baseSKIn['U'].shape, dtype=baseSKIn['U'].dtype.descr[0][1])
+                    baseSKOut['XY_real'][:] = baseSKIn['U'][:]
                     
                     for key in baseSKIn['U'].attrs:
-                        baseSKOut['XY'].attrs[key] = baseSKIn['U'].attrs[key]
+                        baseSKOut['XY_real'].attrs[key] = baseSKIn['U'].attrs[key]
                         
-                ## YX
-                print("      Computing 'YX'")
-                tuningOut.create_dataset('YX', tuningIn['U'].shape, dtype=tuningIn['U'].dtype.descr[0][1])
-                tuningOut['YX'][:] = (tuningIn['U'][:] - tuningIn['V'])/2.0
+                ## XY_imag
+                print("      Computing 'XY_imag'")
+                tuningOut.create_dataset('XY_imag', tuningIn['V'].shape, dtype=tuningIn['V'].dtype.descr[0][1])
+                tuningOut['XY_imag'][:] = tuningIn['V'][:]/2.0
                 
-                for key in tuningIn['U'].attrs:
-                    tuningOut['YX'].attrs[key] = tuningIn['U'].attrs[key]
+                for key in tuningIn['V'].attrs:
+                    tuningOut['XY_imag'].attrs[key] = tuningIn['V'].attrs[key]
                     
                 if baseMaskIn is not None:
-                    baseMaskOut.create_dataset('YX', baseMaskIn['U'].shape, dtype=baseMaskIn['U'].dtype.descr[0][1])
-                    baseMaskOut['YX'][:] = baseMaskIn['U'][:] & baseMaskIn['V'][:]
+                    baseMaskOut.create_dataset('XY_imag', baseMaskIn['V'].shape, dtype=baseMaskIn['V'].dtype.descr[0][1])
+                    baseMaskOut['XY_imag'][:] = baseMaskIn['V'][:]
                     
-                    for key in baseMaskIn['U'].attrs:
-                        baseMaskOut['YX'].attrs[key] = baseMaskIn['U'].attrs[key]
+                    for key in baseMaskIn['V'].attrs:
+                        baseMaskOut['XY_imag'].attrs[key] = baseMaskIn['V'].attrs[key]
                         
                 if baseSKIn is not None:
-                    baseSKOut.create_dataset('YX', baseSKIn['U'].shape, dtype=baseSKIn['U'].dtype.descr[0][1])
-                    baseSKOut['YX'][:] = (baseSKIn['U'][:] + baseSKIn['V'][:]) / 2.0
+                    baseSKOut.create_dataset('XY_imag', baseSKIn['V'].shape, dtype=baseSKIn['V'].dtype.descr[0][1])
+                    baseSKOut['XY_imag'][:] = baseSKIn['V'][:]
                     
-                    for key in baseSKIn['U'].attrs:
-                        baseSKOut['YX'].attrs[key] = baseSKIn['U'].attrs[key]
+                    for key in baseSKIn['V'].attrs:
+                        baseSKOut['XY_imag'].attrs[key] = baseSKIn['V'].attrs[key]
     # Done!
     hIn.close()
     hOut.close()

--- a/DRX/HDF5/stokes2linear.py
+++ b/DRX/HDF5/stokes2linear.py
@@ -49,7 +49,7 @@ def _cloneStructure(input, output, level=0):
         if type(entity).__name__ == 'Dataset':
             ### If so, add it and fill it in
             if ent in ('Steps', 'Delays', 'Gains', 'time', 'Saturation', 'freq'):
-                entityO = output.create_dataset(ent, entity.shape, entity.dtype.descr[0][1])
+                entityO = output.create_dataset(ent, entity.shape, entity.dtype)
                 entityO[:] = entity[:]
                 
             else:


### PR DESCRIPTION
This PR adds support for the new DR spectrometer modes ([LSL PR#19](https://github.com/lwa-project/lsl/pull/19)), adds support for HDF5 power beam files from the OVRO-LWA, and changes how time is stored in the HDF5 files.  Inside the HDF5 files the time is now represented as a two element tuple of (integer seconds since the unix epoch, fractional second) to be compatible with the `lsl.reader.base.FrameTimestamp` class.