### PR TITLE
Add a requirements.txt file

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,10 +42,7 @@ jobs:
           run: |
             pip install numpy
             pip install -r requirements.txt
-        - name: "Software Install - Python, Part 2"
-          run: |
-            pip install \
-              pylint
+            pip install pylint
         - name: Build
           run: |
             cd TBN/Calibration

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,16 +39,12 @@ jobs:
         - uses: actions/checkout@v2
         - name: "Software Install - Python"
           run: |
+            pip install numpy
+            pip install -r requirements.txt
+        - name: "Software Install - Python, Part 2"
+          run: |
             pip install \
-              setuptools \
-              numpy \
-              matplotlib \
-              scipy \
-              h5py
-            pip install \
-              git+https://github.com/lwa-project/lsl.git
-            pip install \
-             pylint
+              pylint
         - name: Build
           run: |
             cd TBN/Calibration

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,6 +25,7 @@ jobs:
               libfftw3-dev \
               libhdf5-dev \
               libgdbm-dev \
+              libwxgtk3-dev \
               pkg-config
         - name: "Software Install - MacOS"
           if: ${{ matrix.os == 'macos-latest' }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ jobs:
               libfftw3-dev \
               libhdf5-dev \
               libgdbm-dev \
-              libwxgtk3-dev \
+              libgtk-3-dev \
               pkg-config
         - name: "Software Install - MacOS"
           if: ${{ matrix.os == 'macos-latest' }}

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 LWA Commissioning Scripts
 =========================
 This is a collection of scripts use for commissioning and testing at the LWA1 
-and LWA-SV stations.  All of the scripts (everything except for TBF) depend 
-on the LSL 0.6.x branch.  The TBF-related scripts depend on the LSL 1.2.x 
-branch.
+and LWA-SV stations.  No installation (e.g., python setup.py install) is required
+to use the software but a `requirements.txt` file is provided to help setup the
+Python environment.
 
 time2time.py
 ------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ scipy
 h5py
 lsl
 wxpython
-bottleneck
+bottleneck; python_version > '2.7'

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,5 @@ scipy
 h5py
 lsl
 wxpython
+healpy < 1.14.0; python_version <= '2.7'
 bottleneck; python_version > '2.7'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+setuptools
+numpy
+matplotlib
+scipy
+h5py
+lsl
+wxpython
+bottleneck


### PR DESCRIPTION
This PR adds a `requirements.txt` file to help install the dependencies needed by commissioning.